### PR TITLE
Use importlib instead of django.utils.importlib

### DIFF
--- a/src/decorator_include/__init__.py
+++ b/src/decorator_include/__init__.py
@@ -5,9 +5,9 @@ reverse order, to all views in the included urlconf.
 """
 from __future__ import unicode_literals
 from builtins import object
+from importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
-from django.utils.importlib import import_module
 
 
 class DecoratedPatterns(object):


### PR DESCRIPTION
django.utils.importlib will be removed in 1.9 `.tox/py34/lib/python3.4/importlib/_bootstrap.py:321: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9. return f(*args, **kwds)`

This library supports Py2.7, 3.2, 3.3, 3.4, all of them have `importlib` as build-in.