### PR TITLE
Add an __iter__ method to DecoratedPatterns.

### DIFF
--- a/src/decorator_include/__init__.py
+++ b/src/decorator_include/__init__.py
@@ -64,6 +64,9 @@ class DecoratedPatterns(object):
         return [self.decorate_pattern(pattern) for pattern in patterns]
     urlpatterns = property(_get_urlpatterns)
 
+    def __iter__(self):
+        return iter(self._get_urlpatterns())
+
     def __getattr__(self, name):
         return getattr(self.urlconf_module, name)
 


### PR DESCRIPTION
In RegexURLResolver.url_patterns Django calls iter() on the
pattern. If the pattern is an instance of DecoratedPatterns this call
will fail and raise an ImproperlyConfigured error. I noticed this when
using decorator_include on admin.site.urls.