### PR TITLE
Remove deprecated, bundled importlib in favor of stdlib version.

### DIFF
--- a/src/decorator_include/__init__.py
+++ b/src/decorator_include/__init__.py
@@ -5,9 +5,9 @@ reverse order, to all views in the included urlconf.
 """
 from __future__ import unicode_literals
 from builtins import object
+from importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
-from django.utils.importlib import import_module
 
 
 class DecoratedPatterns(object):


### PR DESCRIPTION
The bundled importlib in Django was deprecated in version 1.7 and will
be removed in 1.9.