### PR TITLE
Close file after reading in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from setuptools import setup
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    with open(os.path.join(os.path.dirname(__file__), fname)) as fp:
+        return fp.read()
 
 
 setup(


### PR DESCRIPTION
Fixes warning:

```
setup.py:8: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.rst' mode='r' encoding='UTF-8'>
  return open(os.path.join(os.path.dirname(__file__), fname)).read()
```