### PR TITLE
Remove DEBUG from test settings

### DIFF
--- a/src/decorator_include/tests/testproject/settings.py
+++ b/src/decorator_include/tests/testproject/settings.py
@@ -1,8 +1,5 @@
 from __future__ import unicode_literals
 
-DEBUG = True
-TEMPLATE_DEBUG = DEBUG
-
 SECRET_KEY = '8qw5o&7!g&4kg#+4jr6y%qoj6(1s1ufjqo1#x)fqaca&)$2)ba'
 
 DATABASES = {


### PR DESCRIPTION
Django always sets DEBUG to False prior to running tests. It is
pointless to set this value in the test settings and only adds noise.