### PR TITLE
Use isort to sort import statements consistently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,12 @@ matrix:
 
 install:
   - pip install flake8
+  - pip install isort
   - pip install $DJANGO
   - pip install -e .
 
-before_script: flake8
+before_script:
+  - flake8
+  - isort --check-only --diff
 
 script: ./runtests.sh

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,10 @@ universal = 1
 
 [flake8]
 max-line-length = 119
+
+[isort]
+default_section = THIRDPARTY
+known_first_party = decorator_include
+line_length = 79
+multi_line_output = 5
+not_skip = __init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+
 from setuptools import setup
 
 

--- a/src/decorator_include/__init__.py
+++ b/src/decorator_include/__init__.py
@@ -5,7 +5,9 @@ reverse order, to all views in the included urlconf.
 """
 
 from __future__ import unicode_literals
+
 from importlib import import_module
+
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 from django.utils import six

--- a/src/decorator_include/tests/included.py
+++ b/src/decorator_include/tests/included.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from django.conf.urls import include, url
 from django.http import HttpResponse
 

--- a/src/decorator_include/tests/included2.py
+++ b/src/decorator_include/tests/included2.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from django.conf.urls import url
 from django.http import HttpResponse
 

--- a/src/decorator_include/tests/tests.py
+++ b/src/decorator_include/tests/tests.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from django.test import TestCase
 
 

--- a/src/decorator_include/tests/urls.py
+++ b/src/decorator_include/tests/urls.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
+
 from django.conf.urls import url
-from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse
 
 from decorator_include import decorator_include
 


### PR DESCRIPTION
Removes need to think about import order. All files now style imports in
an identical fashion. Loosely based config off Django's.