### PR TITLE
Remove incorrect description of requirements from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,6 @@ install from the GitHub repository::
 
     pip install git+git://github.com/twidi/django-decorator-include.git#egg=django-decorator-include
 
-Requirements
-------------
-
-The only required package is ``future``, used for compatibility with python 2 and python 3
-
 Usage
 -----
 


### PR DESCRIPTION
Requirement on future was removed in
46746ab6113c2cea9665a277762c5c9aed4e3b6d in favor of Django's bundled
six library.