### PR TITLE
Bring test settings in line with modern Django

### DIFF
--- a/src/decorator_include/tests/testproject/settings.py
+++ b/src/decorator_include/tests/testproject/settings.py
@@ -1,14 +1,9 @@
 from __future__ import unicode_literals
 
-SECRET_KEY = '8qw5o&7!g&4kg#+4jr6y%qoj6(1s1ufjqo1#x)fqaca&)$2)ba'
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-    }
-}
+SECRET_KEY = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
 
 INSTALLED_APPS = [
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -17,9 +12,8 @@ INSTALLED_APPS = [
     'decorator_include',
 ]
 
-ROOT_URLCONF = 'decorator_include.tests.urls'
-
 MIDDLEWARE_CLASSES = [
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -27,3 +21,11 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+ROOT_URLCONF = 'decorator_include.tests.urls'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+    },
+}

--- a/src/decorator_include/tests/tests.py
+++ b/src/decorator_include/tests/tests.py
@@ -104,7 +104,11 @@ class IncludeDecoratedTestCase(TestCase):
         self.assertEqual(len(result), 3)
         self.assertEqual(result[0].__class__.__name__, 'DecoratedPatterns')
         patterns = result[0].urlpatterns
-        self.assertEqual(len(patterns), 2)
+        # 3 URL patterns
+        #   /
+        #   /include/
+        #   /admin/
+        self.assertEqual(len(patterns), 3)
         self.assertEqual(patterns[0].callback.decorator_flag, 'test')
 
     def test_multiple_decorators(self):

--- a/src/decorator_include/tests/urls.py
+++ b/src/decorator_include/tests/urls.py
@@ -1,10 +1,15 @@
 from __future__ import unicode_literals
 
 from django.conf.urls import url
+from django.contrib import admin
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 
 from decorator_include import decorator_include
+
+
+def identity(func):
+    return func
 
 
 def index(request):
@@ -14,4 +19,5 @@ def index(request):
 urlpatterns = [
     url(r'^$', index, name='index'),
     url(r'^include/', decorator_include(login_required, 'decorator_include.tests.included')),
+    url(r'^admin/', decorator_include(identity, admin.site.urls)),
 ]


### PR DESCRIPTION
* Use an obviously not secret value for SECRET_KEY
* Order settings the same as Django's startproject
* Use more default values form Django's startproject to simulate a
  default install
* Include admin app in test URLs to test decorator_include works with
  admin