### PR TITLE
Replaced django.core.urlresolvers in favor of django.urls.

### DIFF
--- a/decorator_include.py
+++ b/decorator_include.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
+from django.urls import RegexURLPattern, RegexURLResolver
 from django.utils import six
 
 


### PR DESCRIPTION
Fixed warning RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls in Django 1.11, drops support for 1.5