### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/decorator_include.py
+++ b/decorator_include.py
@@ -12,7 +12,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 from django.utils import six
 
-
 VERSION = (1, 3)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@ universal = 1
 [flake8]
 max-line-length = 119
 
+[metadata]
+license_file = LICENSE
+
 [isort]
 default_section = THIRDPARTY
 known_first_party = decorator_include


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file