### PR TITLE
Add support for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ matrix:
       env: DJANGO="Django>=1.11,<2.0"
     - python: 3.6
       env: DJANGO="Django>=1.11,<2.0"
+    - python: 3.4
+      env: DJANGO="Django>=2.0b1,<2.1"
+    - python: 3.5
+      env: DJANGO="Django>=2.0b1,<2.1"
+    - python: 3.6
+      env: DJANGO="Django>=2.0b1,<2.1"
 
 install:
   - pip install $DJANGO

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 UNRELEASED
 ----------
 * Remove support for Python 3.2.
+* Add support for Django 2.0.
 
 Release *v1.3* - ``2017-05-16``
 -----------------------------

--- a/decorator_include.py
+++ b/decorator_include.py
@@ -33,15 +33,12 @@ class DecoratedPatterns(object):
 
     def decorate_pattern(self, pattern):
         if isinstance(pattern, RegexURLResolver):
-            regex = pattern.regex.pattern
-            urlconf_module = pattern.urlconf_name
-            default_kwargs = pattern.default_kwargs
-            namespace = pattern.namespace
-            app_name = pattern.app_name
-            urlconf = DecoratedPatterns(urlconf_module, self.decorators)
             decorated = RegexURLResolver(
-                regex, urlconf, default_kwargs,
-                app_name, namespace
+                pattern.regex.pattern,
+                DecoratedPatterns(pattern.urlconf_name, self.decorators),
+                pattern.default_kwargs,
+                pattern.app_name,
+                pattern.namespace,
             )
         else:
             callback = pattern.callback
@@ -51,7 +48,7 @@ class DecoratedPatterns(object):
                 pattern.regex.pattern,
                 callback,
                 pattern.default_args,
-                pattern.name
+                pattern.name,
             )
         return decorated
 

--- a/decorator_include.py
+++ b/decorator_include.py
@@ -9,9 +9,16 @@ from __future__ import unicode_literals
 from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
 from django.utils import six
 from django.utils.functional import cached_property
+
+try:
+    from django.urls import URLPattern, URLResolver
+    django_2_0_patterns = True
+except ImportError:
+    # Django < 2.0
+    from django.core.urlresolvers import RegexURLPattern as URLPattern, RegexURLResolver as URLResolver
+    django_2_0_patterns = False
 
 VERSION = (1, 3)
 
@@ -32,9 +39,9 @@ class DecoratedPatterns(object):
         self.decorators = decorators
 
     def decorate_pattern(self, pattern):
-        if isinstance(pattern, RegexURLResolver):
-            decorated = RegexURLResolver(
-                pattern.regex.pattern,
+        if isinstance(pattern, URLResolver):
+            decorated = URLResolver(
+                pattern.pattern if django_2_0_patterns else pattern.regex.pattern,
                 DecoratedPatterns(pattern.urlconf_name, self.decorators),
                 pattern.default_kwargs,
                 pattern.app_name,
@@ -44,8 +51,8 @@ class DecoratedPatterns(object):
             callback = pattern.callback
             for decorator in reversed(self.decorators):
                 callback = decorator(callback)
-            decorated = RegexURLPattern(
-                pattern.regex.pattern,
+            decorated = URLPattern(
+                pattern.pattern if django_2_0_patterns else pattern.regex.pattern,
                 callback,
                 pattern.default_args,
                 pattern.name,

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,7 +12,7 @@ INSTALLED_APPS = [
     'tests',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -21,6 +21,8 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+# Django < 1.10
+MIDDLEWARE_CLASSES = MIDDLEWARE
 
 ROOT_URLCONF = 'tests.urls'
 


### PR DESCRIPTION
To assist with adding Django 2.0 support, I've added a few intermediate commits:

* More closely implement Django urls classes
* Prefer testing with `MIDDLEWARE` instead of `MIDDLEWARE_CLASSES`
* Simplify `.decorate_pattern()` to more easily introduce Django 2.0