### PR TITLE
Remove duplicate trove classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ keywords = django, urls
 classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
-    Framework :: Django :: 1.11
     Framework :: Django :: 2.0
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
@@ -23,9 +22,6 @@ classifiers =
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
-    Framework :: Django
-    Framework :: Django :: 1.11
-    Framework :: Django :: 2.0
     Topic :: Internet :: WWW/HTTP
 
 [options]


### PR DESCRIPTION
No longer need trove classifier for Django 1.11.