### PR TITLE
Fix Python 2 compatibility

### DIFF
--- a/decorator_include.py
+++ b/decorator_include.py
@@ -67,7 +67,7 @@ class DecoratedPatterns(object):
 
     @cached_property
     def urlconf_module(self):
-        if isinstance(self.urlconf_name, six.string_type):
+        if isinstance(self.urlconf_name, six.string_types):
             return import_module(self.urlconf_name)
         else:
             return self.urlconf_name

--- a/decorator_include.py
+++ b/decorator_include.py
@@ -67,7 +67,7 @@ class DecoratedPatterns(object):
 
     @cached_property
     def urlconf_module(self):
-        if isinstance(self.urlconf_name, six.text_type):
+        if isinstance(self.urlconf_name, six.string_type):
             return import_module(self.urlconf_name)
         else:
             return self.urlconf_name


### PR DESCRIPTION
The `six.text_type` applies to `str` in Python 3 but to `unicode` in Python 2, that creates an issue for url modules declared as `str` and not `unicode`. The `six.string_type` applies to `basestring` in Python 2 and `str` in Python 3, which coincides with what Django does internally when importing.