### PR TITLE
Import setuptools.config lazily to work with old setuptools

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ UNRELEASED
 ----------
 * Added testing and support for Django 2.1 and Python 3.7. No code changes were
   required.
+* Fixed ImportError when installed on environments with an old version of
+  setuptools.
 
 Release *v2.0* - ``2018-01-26``
 -------------------------------

--- a/decorator_include.py
+++ b/decorator_include.py
@@ -8,7 +8,6 @@ from importlib import import_module
 from os import path
 
 import pkg_resources
-from setuptools.config import read_configuration
 
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import URLPattern, URLResolver
@@ -21,6 +20,7 @@ def _extract_version(package_name):
         version = pkg_resources.get_distribution(package_name).version
     except pkg_resources.DistributionNotFound:
         # if not installed, so we must be in source, with ``setup.cfg`` available
+        from setuptools.config import read_configuration
         _conf = read_configuration(path.join(
             path.dirname(__file__), 'setup.cfg')
         )


### PR DESCRIPTION
`setuptools.config.read_configuration()` Allow was added in setuptools 38.2.5. Some environments may be on an older version of setuptools, but are otherwise compatible with django-decorator-include. The `read_configuration()` function is only required when developing in the source directory; not for the installed library. To easily workaround this, import it only as need.

Fixes import error:

```
      from setuptools.config import read_configuration
  ModuleNotFoundError: No module named 'setuptools.config'
```