### PR TITLE
Fix check errors that occur when testing with Django master

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,6 +22,22 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'tests.urls'
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
Appeared as:

```
  ERRORS:
  ?: (admin.E403) A 'django.template.backends.django.DjangoTemplates' instance must be configured in TEMPLATES in order to use the admin application.
```

To resolve it, use the default TEMPLATES configuration in tests.