### PR TITLE
Allow failures when testing against Django master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 cache: pip
 
 matrix:
+  fast_finish: true
   include:
     - python: 3.4
       env: TOXENV=py34-django20
@@ -31,6 +32,10 @@ matrix:
       dist: xenial
       sudo: true
     - env: TOXENV=lint
+  allow_failures:
+    - env: TOXENV=py35-djangomaster
+    - env: TOXENV=py36-djangomaster
+    - env: TOXENV=py37-djangomaster
 
 install:
   - pip install tox


### PR DESCRIPTION
Django master is a moving target so tests may break for any number of
reasons. Failures should be investigated but not hold back PRs that pass
test against stable Django releases.