### PR TITLE
Add minversion to tox.ini due to "skip_install" feature

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 1.9
 envlist =
     lint
     py{34,35,36,37}-django20


### PR DESCRIPTION
For deatils, see:

https://tox.readthedocs.io/en/latest/config.html#conf-minversion

https://tox.readthedocs.io/en/latest/config.html#conf-skip_install

> New in version 1.9.