### PR TITLE
Test against for Django 2.2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,17 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-django21
     - python: 3.5
-      env: TOXENV=py35-djangomaster
+      env: TOXENV=py35-django22
+    - python: 3.6
+      env: TOXENV=py36-django22
+    - python: 3.7
+      env: TOXENV=py37-django22
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
     - env: TOXENV=lint
   allow_failures:
-    - env: TOXENV=py35-djangomaster
     - env: TOXENV=py36-djangomaster
     - env: TOXENV=py37-djangomaster
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+* Added support for Django 2.2.
+
 Release *v2.1* - ``2018-11-23``
 -------------------------------
 * Added support for Django 2.1 and Python 3.7.

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 2.0
     Framework :: Django :: 2.1
+    Framework :: Django :: 2.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,15 @@ envlist =
     lint
     py{34,35,36,37}-django20
     py{35,36,37}-django21
-    py{35,36,37}-djangomaster
+    py{35,36,37}-django22
+    py{36,37}-djangomaster
 
 [testenv]
 commands = python -m django test --settings=tests.settings tests
 deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:lint]


### PR DESCRIPTION
Announcement:
https://www.djangoproject.com/weblog/2019/apr/01/django-22-released/

Release notes:
https://docs.djangoproject.com/en/2.2/releases/2.2/

Django master has dropped support for Python 3.5.