### PR TITLE
Handle namespace/app_name like the django `include` function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,9 @@
 Changelog
 =========
 
-UNRELEASED
-----------
+UNRELEASED *v3.0*
+-----------------
+* Handle namespace/app_name the same way as Django `include` function
 * Added support for Django 2.2.
 
 Release *v2.1* - ``2018-11-23``

--- a/README.rst
+++ b/README.rst
@@ -28,20 +28,34 @@ Usage
 
 ``decorator_include`` is intended for use in URL confs as a replacement for the
 ``django.conf.urls.include`` function. It works in almost the same way as
-``include``, however the first argument should be either a decorator or an
-iterable of decorators to apply, in reverse order, to all included views. Here
-is an example URL conf::
+``include`` however the first argument should be either a decorator or an
+iterable of decorators to apply to all included views (if an iterable, the order of the
+decorators is the order in which the functions will be applied on the views).
+Herei s an example URL conf::
 
+    from django.contrib import admin
+    from django.core.exceptions import PermissionDenied
     from django.urls import path
-    from django.contrib.auth.decorators import login_required
+    from django.contrib.auth.decorators import login_required, user_passes_test
 
     from decorator_include import decorator_include
 
     from mysite.views import index
 
+    def only_god(func):
+        def check(user):
+            if user.is_authenticated and user.username == 'god':
+                return True
+            raise PermissionDenied
+        return user_passes_test(check)(func)
+
     urlpatterns = [
         path('', views.index, name='index'),
+        # will redirect to login page if not authenticated
         path('secret/', decorator_include(login_required, 'mysite.secret.urls')),
+        # will redirect to login page if not authenticated
+        # will return a 403 http error if the user does not have the "god" username
+        path('admin/', decorator_include([login_required, only_god], admin.site.urls),
     ]
 
 
@@ -67,8 +81,8 @@ Django versions Python versions         Library versions
 1.8             2.7, 3.2, 3.3, 3.4, 3.5 1.3
 1.9, 1.10       2.7, 3.4, 3.5           1.3
 1.11            2.7, 3.4, 3.5, 3.6      1.4.x (>=1.4.1,<2)
-2.0             3.4, 3.5, 3.6, 3.7      2.0
-2.1             3.5, 3.6, 3.7           2.1
+2.0             3.4, 3.5, 3.6, 3.7      3.0.x
+2.1             3.5, 3.6, 3.7           3.0.x
 =============== ======================= ==================
 
 

--- a/decorator_include.py
+++ b/decorator_include.py
@@ -9,8 +9,7 @@ from os import path
 
 import pkg_resources
 
-from django.core.exceptions import ImproperlyConfigured
-from django.urls import URLPattern, URLResolver
+from django.urls import URLPattern, URLResolver, include
 from django.utils.functional import cached_property
 
 
@@ -82,6 +81,10 @@ class DecoratedPatterns(object):
         else:
             return self.urlconf
 
+    @cached_property
+    def app_name(self):
+        return getattr(self.urlconf_module, 'app_name', None)
+
 
 def decorator_include(decorators, arg, namespace=None):
     """
@@ -89,22 +92,12 @@ def decorator_include(decorators, arg, namespace=None):
     or an iterable of view decorators as the first argument and applies them,
     in reverse order, to all views in the included urlconf.
     """
-    app_name = None
-    if isinstance(arg, tuple):
-        # callable returning a namespace hint
-        try:
-            urlconf, app_name = arg
-        except ValueError:
-            if namespace:
-                raise ImproperlyConfigured(
-                    'Cannot override the namespace for a dynamic module that provides a namespace'
-                )
-            # can happen for example when using decorator_include with ``admin.site.urls``
-            urlconf, app_name, namespace = arg
+    if isinstance(arg, tuple) and len(arg) == 3 and not isinstance(arg[0], str):
+        # Special case where the function is used for something like `admin.site.urls`, which
+        # returns a tuple with the object containing the urls, the app name, and the namespace
+        # `include` does not support this pattern (you pass directly `admin.site.urls`, without
+        # using `include`) but we have to
+        urlconf_module, app_name, namespace = arg
     else:
-        # No namespace hint - use manually provided namespace
-        urlconf = arg
-
-    decorated_urlconf = DecoratedPatterns(urlconf, decorators)
-    namespace = namespace or app_name
-    return (decorated_urlconf, app_name, namespace)
+        urlconf_module, app_name, namespace = include(arg, namespace=namespace)
+    return DecoratedPatterns(urlconf_module, decorators), app_name, namespace

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-decorator-include
-version = 2.1
+version = 3.0.dev0
 author = Jeff Kistler
 author_email = jeff@jeffkistler.com
 url = https://github.com/twidi/django-decorator-include

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,14 @@
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
 from django.test import TestCase
+from django.urls import path
+
+
+def test_decorator(func):
+    func.tested = True
+    return func
 
 
 class IncludeDecoratedTestCase(TestCase):
@@ -9,67 +19,92 @@ class IncludeDecoratedTestCase(TestCase):
     def test_basic(self):
         decorator_include = self.get_decorator_include()
 
-        def test_decorator(func):
-            func.tested = True
-            return func
-
-        result = decorator_include(test_decorator, 'tests.urls')
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0].__class__.__name__, 'DecoratedPatterns')
-        self.assertIsNone(result[1])
-        self.assertIsNone(result[2])
+        urlconf, app_name, namespace = decorator_include(test_decorator, 'tests.urls')
+        self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+        # use app_name defined in tests.urls
+        self.assertEqual(app_name, 'app_name_tests')
+        # if not defined, the namespace is the app_name
+        self.assertEqual(namespace, 'app_name_tests')
 
     def test_basic_namespace(self):
         decorator_include = self.get_decorator_include()
 
-        def test_decorator(func):
-            func.tested = True
-            return func
-
-        result = decorator_include(test_decorator, 'tests.urls', 'test')
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0].__class__.__name__, 'DecoratedPatterns')
-        self.assertIsNone(result[1])
-        self.assertEqual(result[2], 'test')
+        urlconf, app_name, namespace = decorator_include(test_decorator, 'tests.urls', 'test')
+        self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+        # use app_name defined in tests.urls
+        self.assertEqual(app_name, 'app_name_tests')
+        # use passed namespace
+        self.assertEqual(namespace, 'test')
 
     def test_basic_2_tuple(self):
         decorator_include = self.get_decorator_include()
 
-        def test_decorator(func):
-            func.tested = True
-            return func
+        urlconf, app_name, namespace = decorator_include(test_decorator, ('tests.urls', 'testapp'))
+        self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+        # use app_name defined in tests.urls even if passed in the tuple
+        self.assertEqual(app_name, 'app_name_tests')
+        # if not defined, the namespace is the app_name
+        self.assertEqual(namespace, 'app_name_tests')
 
-        result = decorator_include(test_decorator, ('tests.urls', 'test'))
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0].__class__.__name__, 'DecoratedPatterns')
-        self.assertEqual(result[1], 'test')
-        self.assertEqual(result[2], 'test')
+        # temporarily remove app_name from `tests.urls` to ensure it will use the provided one
+        from tests import urls
+        old_app_name = urls.app_name
+        try:
+            del urls.app_name
+            urlconf, app_name, namespace = decorator_include(test_decorator, ('tests.urls', 'testapp'))
+            self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+            # no app_name in tests.urls, we use the one passed in the tuple
+            self.assertEqual(app_name, 'testapp')
+            # if not defined, the namespace is the app_name
+            self.assertEqual(namespace, 'testapp')
+        finally:
+            urls.app_name = old_app_name
 
     def test_basic_2_tuple_namespace(self):
         decorator_include = self.get_decorator_include()
 
-        def test_decorator(func):
-            func.tested = True
-            return func
+        urlconf, app_name, namespace = decorator_include(test_decorator, ('tests.urls', 'testapp'), 'testns')
+        self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+        # use app_name defined in tests.urls even if passed in the tuple
+        self.assertEqual(app_name, 'app_name_tests')
+        # use passed namespace
+        self.assertEqual(namespace, 'testns')
 
-        result = decorator_include(test_decorator, ('tests.urls', 'testapp'), 'testns')
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0].__class__.__name__, 'DecoratedPatterns')
-        self.assertEqual(result[1], 'testapp')
-        self.assertEqual(result[2], 'testns')
+        # temporarily remove app_name from `tests.urls` to ensure it will use the provided one
+        from tests import urls
+        old_app_name = urls.app_name
+        try:
+            del urls.app_name
+            urlconf, app_name, namespace = decorator_include(test_decorator, ('tests.urls', 'testapp'), 'testns')
+            self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+            # no app_name in tests.urls, we use the one passed in the tuple
+            self.assertEqual(app_name, 'testapp')
+            # use passed namespace
+            self.assertEqual(namespace, 'testns')
+        finally:
+            urls.app_name = old_app_name
 
     def test_basic_3_tuple(self):
         decorator_include = self.get_decorator_include()
 
-        def test_decorator(func):
-            func.tested = True
-            return func
+        # passing a 3 tuple with a python path for the urls module is not allowed
+        with self.assertRaises(ImproperlyConfigured):
+            decorator_include(test_decorator, ('tests.urls', 'testapp', 'testns'))
 
-        result = decorator_include(test_decorator, ('tests.urls', 'testapp', 'testns'))
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0].__class__.__name__, 'DecoratedPatterns')
-        self.assertEqual(result[1], 'testapp')
-        self.assertEqual(result[2], 'testns')
+        # but it is allowed when the first item can return directly urls, like the admin urls
+        urlconf, app_name, namespace = decorator_include(test_decorator, admin.site.urls)
+        self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+        self.assertEqual(app_name, 'admin')
+        self.assertEqual(namespace, 'admin')
+
+        # or directly a list
+        urlpatterns = [
+            path('myview/', lambda request: HttpResponse('view'), name='myview'),
+        ]
+        urlconf, app_name, namespace = decorator_include(test_decorator, (urlpatterns, 'myviewsapp', 'myviewsns'))
+        self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+        self.assertEqual(app_name, 'myviewsapp')
+        self.assertEqual(namespace, 'myviewsns')
 
     def test_get_urlpatterns(self):
         decorator_include = self.get_decorator_include()
@@ -78,15 +113,15 @@ class IncludeDecoratedTestCase(TestCase):
             func.decorator_flag = 'test'
             return func
 
-        result = decorator_include(test_decorator, 'tests.urls')
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0].__class__.__name__, 'DecoratedPatterns')
-        patterns = result[0].urlpatterns
+        urlconf, app_name, namespace = decorator_include(test_decorator, 'tests.urls')
+        self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+        patterns = urlconf.urlpatterns
         # 3 URL patterns
         #   /
         #   /include/
         #   /admin/
-        self.assertEqual(len(patterns), 3)
+        #   /only-god/
+        self.assertEqual(len(patterns), 4)
         self.assertEqual(patterns[0].callback.decorator_flag, 'test')
 
     def test_multiple_decorators(self):
@@ -101,9 +136,9 @@ class IncludeDecoratedTestCase(TestCase):
             func.decorated_by = 'second'
             return func
 
-        result = decorator_include((first_decorator, second_decorator), 'tests.urls')
-        self.assertEqual(result[0].__class__.__name__, 'DecoratedPatterns')
-        patterns = result[0].urlpatterns
+        urlconf, app_name, namespace = decorator_include((first_decorator, second_decorator), 'tests.urls')
+        self.assertEqual(urlconf.__class__.__name__, 'DecoratedPatterns')
+        patterns = urlconf.urlpatterns
         pattern = patterns[0]
         self.assertEqual(pattern.callback.decorator_flag, 'first')
         self.assertEqual(pattern.callback.decorated_by, 'second')
@@ -115,8 +150,8 @@ class IncludeDecoratedTestCase(TestCase):
             func.decorator_flag = 'test'
             return func
 
-        result = decorator_include(test_decorator, 'tests.urls')
-        patterns = result[0].urlpatterns
+        urlconf, app_name, namespace = decorator_include(test_decorator, 'tests.urls')
+        patterns = urlconf.urlpatterns
         decorated = patterns[1]
         self.assertEqual(decorated.url_patterns[1].callback.decorator_flag, 'test')
         decorated = patterns[1].url_patterns[0].url_patterns[0]
@@ -133,3 +168,28 @@ class IncludeDecoratedTestCase(TestCase):
     def test_get_deeply_nested(self):
         response = self.client.get('/include/included/deeply_nested/')
         self.assertEqual(response.status_code, 302)
+
+    def test_multiple_decorators_real_case(self):
+        # the `/only-god/` path is decorated with two decorators:
+        # - `login_required` that will redirect to login page if not authenticated
+        # - `only_god` that will raise a 403 if it's not the "god" user
+
+        # not authenticated will redirect to login page
+        response = self.client.get('/only-god/test/')
+        self.assertEqual(response.status_code, 302)
+
+        # authenticated as god is ok
+        god = User(username='god')
+        god.set_password('foo')
+        god.save()
+        self.client.login(username='god', password='foo')
+        response = self.client.get('/only-god/test/')
+        self.assertEqual(response.status_code, 200)
+
+        # authenticated as another user will raise
+        notgod = User(username='notgod')
+        notgod.set_password('foo')
+        notgod.save()
+        self.client.login(username='notgod', password='foo')
+        response = self.client.get('/only-god/test/')
+        self.assertEqual(response.status_code, 403)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.urls import path
 
@@ -10,12 +11,23 @@ def identity(func):
     return func
 
 
+def only_god(func):
+    def check(user):
+        if user.is_authenticated and user.username == 'god':
+            return True
+        raise PermissionDenied
+    return user_passes_test(check)(func)
+
+
 def index(request):
     return HttpResponse('Index!')
 
+
+app_name = 'app_name_tests'
 
 urlpatterns = [
     path('', index, name='index'),
     path('include/', decorator_include(login_required, 'tests.included')),
     path('admin/', decorator_include(identity, admin.site.urls)),
+    path('only-god/', decorator_include([login_required, only_god], 'tests.included')),
 ]


### PR DESCRIPTION
This is done by simply calling `include` and decorating the result,
instead of using our own code - which was wrong - to mimic the `include`
behavior.

The only difference is that we accept "3-tuple" to be able to decorate
stuff like `admin.site.urls`.

This commit also had a test when passing an iterable of decorators, not
only just one, and show an example of this in the README.

This commit is *breaking* the old (and erroneous) behaviour of the
`decorator_include` function so it will be for the next MAJOR version.