### PR TITLE
Ensure parameterized decorators are accepted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 UNRELEASED *v3.0*
 -----------------
 * Handle namespace/app_name the same way as Django `include` function
+* Ensure parameterized decorators are accepted
 * Added support for Django 2.2 and 3.0
 * Added support for Python 3.8
 

--- a/README.rst
+++ b/README.rst
@@ -42,12 +42,12 @@ Herei s an example URL conf::
 
     from mysite.views import index
 
-    def only_god(func):
+    def only_user(username):
         def check(user):
-            if user.is_authenticated and user.username == 'god':
+            if user.is_authenticated and user.username == username:
                 return True
             raise PermissionDenied
-        return user_passes_test(check)(func)
+        return user_passes_test(check)
 
     urlpatterns = [
         path('', views.index, name='index'),
@@ -55,7 +55,7 @@ Herei s an example URL conf::
         path('secret/', decorator_include(login_required, 'mysite.secret.urls')),
         # will redirect to login page if not authenticated
         # will return a 403 http error if the user does not have the "god" username
-        path('admin/', decorator_include([login_required, only_god], admin.site.urls),
+        path('admin/', decorator_include([login_required, only_user('god')], admin.site.urls),
     ]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-decorator-include
-version = 3.0.dev1
+version = 3.0.dev2
 author = Jeff Kistler
 author_email = jeff@jeffkistler.com
 url = https://github.com/twidi/django-decorator-include

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
-from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.decorators import (
+    login_required, permission_required, user_passes_test
+)
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.urls import path
@@ -11,12 +13,12 @@ def identity(func):
     return func
 
 
-def only_god(func):
+def only_user(username):
     def check(user):
-        if user.is_authenticated and user.username == 'god':
+        if user.is_authenticated and user.username == username:
             return True
         raise PermissionDenied
-    return user_passes_test(check)(func)
+    return user_passes_test(check)
 
 
 def index(request):
@@ -29,5 +31,9 @@ urlpatterns = [
     path('', index, name='index'),
     path('include/', decorator_include(login_required, 'tests.included')),
     path('admin/', decorator_include(identity, admin.site.urls)),
-    path('only-god/', decorator_include([login_required, only_god], 'tests.included')),
+    path('only-god/', decorator_include([login_required, only_user('god')], 'tests.included')),
+    path('with-perm/', decorator_include(
+        [login_required, permission_required('auth.is_god', raise_exception=True)],
+        'tests.included'
+    ))
 ]


### PR DESCRIPTION
We check with the `permission_required` decorator provided by django,
and one we created in our tests (that we show in README as an example)