### PR TITLE
Update tox.ini to work with isort 5.0.0+ and simplify its config

### DIFF
--- a/decorator_include.py
+++ b/decorator_include.py
@@ -8,7 +8,6 @@ from importlib import import_module
 from os import path
 
 import pkg_resources
-
 from django.urls import URLPattern, URLResolver, include
 from django.utils.functional import cached_property
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,11 +44,4 @@ dev =
 max-line-length = 119
 
 [isort]
-default_section = THIRDPARTY
-known_first_party = decorator_include
-known_django = django
-sections = STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
-line_length = 79
-multi_line_output = 5
-not_skip = __init__.py
-skip = .tox
+profile = django

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.decorators import (
-    login_required, permission_required, user_passes_test
+    login_required, permission_required, user_passes_test,
 )
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,8 @@ deps =
 basepython = python3
 commands =
     flake8
-    isort --check-only --diff
+    isort --check-only --diff .
 deps =
     flake8
-    isort
+    isort>=5.0.1
 skip_install = true


### PR DESCRIPTION
Can now use the profile "django" to automatically adopt Django isort
configuration.

isort change their default ignore and skip values, so specifying them is
no longer necessary.