### PR TITLE
Remove remaining references to EOL Django 2.0 and 2.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,6 @@ envlist =
 [testenv]
 commands = python -m django test --settings=tests.settings tests
 deps =
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2


### PR DESCRIPTION
These lines were missed in 4858319ed914894e32b8eaf3ae4b59fb5925aa2a.